### PR TITLE
Support empty relationship data

### DIFF
--- a/src/__mocks__/product_with_includes.json
+++ b/src/__mocks__/product_with_includes.json
@@ -121,12 +121,6 @@
         }
       },
       "special_categories": {
-        "data": [
-          {
-            "type": "taxonomy-term--special-categories",
-            "id": "5ac7df92-6021-4de7-886d-4618bc7513ec"
-          }
-        ],
         "links": {
           "related": {
             "href": "https:\/\/example.dev\/jsonapi\/products\/simple\/611e61c2-ea66-49fe-ae23-73dea19a631c\/special_categories"

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -27,4 +27,7 @@ test('mapped include', () => {
     throw new Error('categories is a multi value relationship');
   }
   expect(categories.length).toBe(6);
+
+  const emptyRelationship = getRelationshipFromMappedIncludes(product.data, 'special_categories', mappedIncludes);
+  expect(emptyRelationship === null);
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,6 +26,9 @@ export const getRelationshipFromMappedIncludes = (
   if (!relationship) {
     return null;
   }
+  if (!relationship.data) {
+    return null;
+  }
   if (Array.isArray(relationship.data)) {
     return relationship.data.map((identifier: ResourceIdentifier) => {
       return mappedIncludes[identifier.type][identifier.id];


### PR DESCRIPTION
Fixes #3
- Add test showing empty relationships cause an error
- Handle empty relationship `data`
